### PR TITLE
Implement missing pipeline features

### DIFF
--- a/etl/cleaner.py
+++ b/etl/cleaner.py
@@ -82,6 +82,11 @@ def fill_missing_values(df: pd.DataFrame, method: str = 'mean', category_col: st
     return DataCleaner.fill_missing_values(df, method=method, category_col=category_col, threshold=threshold)
 
 
+def fill_missing(df: pd.DataFrame, method: str = 'mean', category_col: str | None = None, threshold: float = 0.05) -> pd.DataFrame:
+    """Compatibilidad: alias de :func:`fill_missing_values`."""
+    return DataCleaner.fill_missing_values(df, method=method, category_col=category_col, threshold=threshold)
+
+
 def remove_outliers(df: pd.DataFrame, column: str, threshold: float = 3.0) -> pd.DataFrame:
     """Wrapper que delega en :class:`DataCleaner` para eliminar outliers."""
     return DataCleaner.remove_outliers(df, column=column, threshold=threshold)

--- a/etl/mappings.py
+++ b/etl/mappings.py
@@ -43,3 +43,10 @@ METEO_COLUMNS_RENAME = {
     'Universidad Panamá 3 - Meteo - Relative Humidity (%)': 'UP3_Humid_pct',
     # 'Universidad Panamá 3 - Meteo - Plant Insolation (kWh/m2)': 'UP3_Ins_kWh_m2',  # calculado manualmente
 }
+
+# Mapeo conveniente para acceder desde el pipeline
+rename_dicts = {
+    'energia': ENERGY_COLUMNS_RENAME,
+    'meteo': METEO_COLUMNS_RENAME,
+    'pvsyst': PVSYST_COLUMNS_RENAME,
+}

--- a/etl/sources/file_source.py
+++ b/etl/sources/file_source.py
@@ -4,31 +4,29 @@ from etl.sources.base_source import DataSource
 
 
 class FileSource(DataSource):
-    """
-    Implementación concreta de DataSource para cargar datos desde archivos locales.
-    Soporta archivos .csv y .xlsx.
-    """
+    """Carga archivos locales (`.csv` o `.xlsx`)."""
 
-    def __init__(self, filepath: str):
-        if not os.path.exists(filepath):
-            raise FileNotFoundError(f"Archivo no encontrado: {filepath}")
-        self.filepath = filepath
+    def __init__(self) -> None:
+        pass
 
-    def load(self) -> pd.DataFrame:
-        """
-        Carga el archivo y elimina columnas innecesarias (tipo 'Unnamed').
-
-        Retorna:
-        pd.DataFrame: DataFrame limpio
-        """
-        if self.filepath.endswith('.csv'):
-            df = pd.read_csv(self.filepath)
-        elif self.filepath.endswith('.xlsx'):
-            df = pd.read_excel(self.filepath)
+    @staticmethod
+    def _load_file(path: str) -> pd.DataFrame:
+        if path.endswith('.csv'):
+            df = pd.read_csv(path)
+        elif path.endswith('.xlsx'):
+            df = pd.read_excel(path)
         else:
             raise ValueError("Formato no soportado. Usa .csv o .xlsx")
 
-        # Eliminar columnas tipo 'Unnamed'
         df = df.loc[:, ~df.columns.str.contains('^Unnamed')]
-
         return df
+
+    def load_excel(self, path: str) -> pd.DataFrame:
+        """Compatibilidad con el pipeline: carga el archivo indicado."""
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"Archivo no encontrado: {path}")
+        return self._load_file(path)
+
+    # Para cumplir la interfaz ``DataSource``
+    def load(self, path: str) -> pd.DataFrame:  # type: ignore[override]
+        return self.load_excel(path)


### PR DESCRIPTION
## Summary
- flesh out `DataTransformer` with pipeline helper methods
- enable `DataCleaner.fill_missing` convenience wrapper
- add `rename_dicts` mapping for column renames
- allow `FileSource` to load arbitrary paths
- ensure tests run against the new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68546fd6cd48832cb9d9df2433d2c8ff